### PR TITLE
Introduce `NAT_PMP_GATEWAY` env variable to manually set nat-pmp gateway

### DIFF
--- a/transmission-nat-pmp/root/etc/s6-overlay/s6-rc.d/svc-mod-transmission-nat-pmp/run
+++ b/transmission-nat-pmp/root/etc/s6-overlay/s6-rc.d/svc-mod-transmission-nat-pmp/run
@@ -1,11 +1,8 @@
 #!/usr/bin/with-contenv bash
 
-# get nat-pmp gateway IP address using the NAT_PMP_GATEWAY env variable or 
-# use the system nameserver as fallback
-if [ -z "${NAT_PMP_GATEWAY}" ]; then
+if [[ -z "${GATEWAY}" ]]; then
+	# fall back to system nameserver if GATEWAY env variable is not set
 	GATEWAY=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
-else 
-	GATEWAY=${NAT_PMP_GATEWAY}
 fi
 
 TRANSMISSION_USERNAME=$USER TRANSMISSION_PASSWORD=$PASS /transmission-nat-pmp -gateway $GATEWAY

--- a/transmission-nat-pmp/root/etc/s6-overlay/s6-rc.d/svc-mod-transmission-nat-pmp/run
+++ b/transmission-nat-pmp/root/etc/s6-overlay/s6-rc.d/svc-mod-transmission-nat-pmp/run
@@ -1,4 +1,11 @@
 #!/usr/bin/with-contenv bash
 
-GATEWAY=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
+# get nat-pmp gateway IP address using the NAT_PMP_GATEWAY env variable or 
+# use the system nameserver as fallback
+if [ -z "${NAT_PMP_GATEWAY}" ]; then
+	GATEWAY=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
+else 
+	GATEWAY=${NAT_PMP_GATEWAY}
+fi
+
 TRANSMISSION_USERNAME=$USER TRANSMISSION_PASSWORD=$PASS /transmission-nat-pmp -gateway $GATEWAY


### PR DESCRIPTION
Fix for some of the issues discussed here: https://github.com/jordanpotter/docker-mods/issues/2. Applied by adding a variable to your docker config like so `-e NAT_PMP_GATEWAY='10.2.0.1'`